### PR TITLE
Handle selector picker message port failures

### DIFF
--- a/selector-picker.js
+++ b/selector-picker.js
@@ -345,9 +345,14 @@ class SelectorPicker {
 // Start picker when receiving message from options page
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'start-picker' && message.data?.targetField) {
-    const picker = new SelectorPicker();
-    picker.start(message.data.targetField);
-    sendResponse({ success: true });
+    try {
+      const picker = new SelectorPicker();
+      picker.start(message.data.targetField);
+      sendResponse({ success: true });
+    } catch (error) {
+      console.error('[ehrqo] Failed to start selector picker', error);
+      sendResponse({ success: false, error: error?.message || String(error) });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure the options page retries selector picker injection when Chrome reports a closed message port
- surface selector picker start failures back to the options UI for better error messages
- guard the selector picker listener so it always responds even when instantiation fails

## Testing
- npm run lint *(fails: missing ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dc9faf6c83208355d6f388c4a8df