### PR TITLE
Stop showing demo recipes in the injected panel

### DIFF
--- a/content.js
+++ b/content.js
@@ -36,58 +36,8 @@ const DEFAULT_CATEGORIES = {
   }
 };
 
-// Example recipes - edit in Options page
-const DEFAULT_RECIPES = [
-  {
-    id: 'ct_head_stroke',
-    label: 'Head CT - stroke',
-    category: 'Imaging/Neuro',
-    config: { 
-      searchTerm: 'Head CT',
-      dropdownText: 'Stroke protocol head CT (non-contrast)',
-      emergency: true,
-      room: '12'
-    },
-    hotkey: 'Ctrl+1',
-    order: 1
-  },
-  {
-    id: 'ct_head_trauma',
-    label: 'Head CT - trauma',
-    category: 'Imaging/Neuro',
-    config: {
-      searchTerm: 'Head CT',
-      dropdownText: 'Non-contrast head CT',
-      emergency: true,
-      room: '12'
-    },
-    order: 2
-  },
-  {
-    id: 'cxr_pa_lat',
-    label: 'Chest X-ray - PA/LAT',
-    category: 'Imaging/Chest',
-    config: {
-      searchTerm: 'Chest X-ray',
-      dropdownText: 'PA and lateral views',
-      emergency: false,
-      room: '12'
-    },
-    order: 1
-  },
-  {
-    id: 'cxr_portable',
-    label: 'Chest X-ray - portable',
-    category: 'Imaging/Chest',
-    config: {
-      searchTerm: 'Chest X-ray',
-      dropdownText: 'Portable AP view',
-      emergency: false,
-      room: '12'
-    },
-    order: 2
-  }
-];
+// No built-in recipes by default; users configure everything via Options.
+const DEFAULT_RECIPES = [];
 
 // ---------------- Utilities ----------------
 const $q = (sel, root = document) => root.querySelector(sel);
@@ -994,7 +944,9 @@ function injectPanel(state) {
     if (recipes.length === 0) {
       content.innerHTML = `
         <div class="ehrqo-empty">
-          ${searchFilter ? 'Receptu nerasta.' : 'Nera receptu.'}
+          ${searchFilter
+            ? 'Receptų nerasta.'
+            : 'Nėra paruoštų šablonų. Atidarykite plėtinio Parinktis ir susikurkite savo receptus.'}
         </div>
       `;
       return;


### PR DESCRIPTION
## Summary
- remove the fallback demo recipes so the panel only reflects configured templates
- show a clearer empty-state message guiding users to configure recipes in the Options page

## Testing
- npm run lint *(fails: missing ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e140e1348320a7c5cdfcdeb9f1a8